### PR TITLE
chore: add permissions section to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, master, develop]
 
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
 jobs:
   commitlint:
     name: Validate Commits

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   validate-pr-title:
     name: Validate PR Title


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to explicitly specify permissions for workflow runs. This change enhances the security and clarity of the workflows by granting only the necessary permissions required for each workflow file.

Workflow permissions configuration:

* In `.github/workflows/ci.yml`, added explicit read permissions for `contents`, `actions`, and `pull-requests` to restrict the workflow to only the minimum required access.
* In `.github/workflows/pr-title.yml`, set `contents: read` and `pull-requests: write` permissions to allow the workflow to read repository contents and modify pull requests as needed.