### PR TITLE
fix: code scanning alert no. 33

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -25,7 +25,9 @@ jobs:
         run: npm install --save-dev @commitlint/cli @commitlint/config-conventional
 
       - name: Validate PR title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | npx commitlint
 
       - name: Comment on PR (if failed)
         if: failure()

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Validate PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx commitlint
+        run: printf '%s\n' "$PR_TITLE" | npx commitlint
 
       - name: Comment on PR (if failed)
         if: failure()

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -42,7 +42,7 @@ jobs:
 
               Your PR title does not follow [Conventional Commits](https://www.conventionalcommits.org/) format.
 
-              **Current title:** \`${{ github.event.pull_request.title }}\`
+              **Current title:** \`${context.payload.pull_request.title}\`
 
               **Expected format:**
               \`\`\`


### PR DESCRIPTION
Potential fix for [https://github.com/NovigoTechnology/nvg-ui/security/code-scanning/33](https://github.com/NovigoTechnology/nvg-ui/security/code-scanning/33)

General fix approach: remove direct `${{ ... }}` interpolation of untrusted input from `run:` scripts. Instead, map the input to a step environment variable and consume it as `$VAR` (shell-native expansion). This prevents expression-time injection into the script body.

Best fix for this file: update only the “Validate PR title” step in `.github/workflows/pr-title.yml`:
- Add an `env:` block with `PR_TITLE: ${{ github.event.pull_request.title }}`.
- Change `run:` from direct interpolation to `echo "$PR_TITLE" | npx commitlint`.

No additional imports, methods, or dependencies are required. Functionality remains the same (still validates the PR title with commitlint).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
